### PR TITLE
Stage 10: global variables

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -32,7 +32,7 @@ impl Codegen {
     }
 
     pub fn codegen(&mut self, ast: AstNode) -> anyhow::Result<String> {
-        let AstNode::Program { function_list } = ast else {
+        let AstNode::Program { function_or_declaration_list: function_list } = ast else {
             return Err(anyhow!("Called codegen on node that is not a program"));
         };
 
@@ -817,7 +817,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen = Codegen::new();
@@ -979,7 +979,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen = Codegen::new();
@@ -1007,7 +1007,7 @@ mod tests {
             body: None,
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen = Codegen::new();
@@ -1032,7 +1032,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen = Codegen::new();
@@ -1117,7 +1117,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1163,7 +1163,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1214,7 +1214,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1258,7 +1258,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1291,7 +1291,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1379,7 +1379,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1480,7 +1480,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();
@@ -1547,7 +1547,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut codegen: Codegen = Codegen::new();

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -197,11 +197,11 @@ impl Codegen {
             result.push_str(&generated_statement);
 
             // if there is no explicit return statement, then return 0
-            // return statements will jump over this instruction to the .Lreturn label
+            // return statements will jump over this instruction to the Lreturn label
             result.push_str(&Self::format_instruction("mov", vec!["w0", "#0"]));
 
             // write label for jumping to early return
-            result.push_str(&format!("{}_{}:\n", ".Lreturn", function_name));
+            result.push_str(&format!("{}_{}:\n", "Lreturn", function_name));
             result.push_str(&self.generate_function_epilogue());
             result.push_str(&Self::format_instruction("ret", vec![]));
         }
@@ -334,7 +334,7 @@ impl Codegen {
                 // jump to return label
                 result.push_str(&Self::format_instruction(
                     "b",
-                    vec![&format!(".Lreturn_{}", codegen_context.function_name)],
+                    vec![&format!("Lreturn_{}", codegen_context.function_name)],
                 ));
             }
             AstNode::If {
@@ -345,8 +345,8 @@ impl Codegen {
                 // evaluate condition
                 result.push_str(&self.generate_expression(condition, codegen_context)?);
 
-                let label_1 = &format!(".L{:?}", self.label_counter);
-                let label_2 = &format!(".L{:?}", self.label_counter + 1);
+                let label_1 = &format!("L{:?}", self.label_counter);
+                let label_2 = &format!("L{:?}", self.label_counter + 1);
                 self.label_counter += 2;
                 // skip to label 1 if condition is false
                 result.push_str(&Self::format_instruction("cmp", vec!["w0", "0"]));
@@ -409,9 +409,9 @@ impl Codegen {
                     }
                 }
 
-                let condition_label = &format!(".L{:?}", self.label_counter);
-                let end_of_body_label: &String = &format!(".L{:?}", self.label_counter + 1);
-                let end_of_loop_label = &format!(".L{:?}", self.label_counter + 2);
+                let condition_label = &format!("L{:?}", self.label_counter);
+                let end_of_body_label: &String = &format!("L{:?}", self.label_counter + 1);
+                let end_of_loop_label = &format!("L{:?}", self.label_counter + 2);
                 self.label_counter += 3;
                 // mark condition with label
                 result.push_str(&format!("{}:\n", condition_label));
@@ -483,9 +483,9 @@ impl Codegen {
                 }
             }
             AstNode::While { condition, body } => {
-                let condition_label = &format!(".L{:?}", self.label_counter);
-                let end_of_body_label: &String = &format!(".L{:?}", self.label_counter + 1);
-                let end_of_loop_label = &format!(".L{:?}", self.label_counter + 2);
+                let condition_label = &format!("L{:?}", self.label_counter);
+                let end_of_body_label: &String = &format!("L{:?}", self.label_counter + 1);
+                let end_of_loop_label = &format!("L{:?}", self.label_counter + 2);
                 self.label_counter += 3;
                 // mark condition with label
                 result.push_str(&format!("{}:\n", condition_label));
@@ -516,9 +516,9 @@ impl Codegen {
                 result.push_str(&format!("{}:\n", end_of_loop_label));
             }
             AstNode::Do { body, condition } => {
-                let start_of_body_label = &format!(".L{:?}", self.label_counter);
-                let end_of_body_label: &String = &format!(".L{:?}", self.label_counter + 1);
-                let end_of_loop_label = &format!(".L{:?}", self.label_counter + 2);
+                let start_of_body_label = &format!("L{:?}", self.label_counter);
+                let end_of_body_label: &String = &format!("L{:?}", self.label_counter + 1);
+                let end_of_loop_label = &format!("L{:?}", self.label_counter + 2);
                 self.label_counter += 3;
                 // mark start of body with label
                 result.push_str(&format!("{}:\n", start_of_body_label));
@@ -639,8 +639,8 @@ impl Codegen {
                         result.push_str(&Self::format_instruction("sdiv", vec!["w0", "w1", "w0"]));
                     }
                     Operator::And => {
-                        let label_1 = &format!(".L{:?}", self.label_counter);
-                        let label_2 = &format!(".L{:?}", self.label_counter + 1);
+                        let label_1 = &format!("L{:?}", self.label_counter);
+                        let label_2 = &format!("L{:?}", self.label_counter + 1);
                         self.label_counter += 2;
                         // skip to label 1 if any value is 0
                         result.push_str(&Self::format_instruction("cmp", vec!["w1", "0"]));
@@ -657,8 +657,8 @@ impl Codegen {
                         result.push_str(&format!("{}:\n", label_2));
                     }
                     Operator::Or => {
-                        let label_1 = &format!(".L{:?}", self.label_counter);
-                        let label_2 = &format!(".L{:?}", self.label_counter + 1);
+                        let label_1 = &format!("L{:?}", self.label_counter);
+                        let label_2 = &format!("L{:?}", self.label_counter + 1);
                         self.label_counter += 2;
                         // skip to label 1 if any value is not 0
                         result.push_str(&Self::format_instruction("cmp", vec!["w1", "0"]));
@@ -725,8 +725,8 @@ impl Codegen {
                 // evaluate condition
                 result.push_str(&self.generate_expression(condition, codegen_context)?);
 
-                let label_1 = &format!(".L{:?}", self.label_counter);
-                let label_2 = &format!(".L{:?}", self.label_counter + 1);
+                let label_1 = &format!("L{:?}", self.label_counter);
+                let label_2 = &format!("L{:?}", self.label_counter + 1);
                 self.label_counter += 2;
                 // skip to label 1 if condition is false
                 result.push_str(&Self::format_instruction("cmp", vec!["w0", "0"]));
@@ -830,9 +830,9 @@ mod tests {
                     stp	x29, x30, [sp, -16]!
                     mov	x29, sp
                     mov	w0, #2
-                    b	.Lreturn_main
+                    b	Lreturn_main
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -884,9 +884,9 @@ mod tests {
                 str	w7, [sp, 0]
                 ldr	w0, [sp, 32]
                 add	sp, sp, 32
-                b	.Lreturn_foo
+                b	Lreturn_foo
                 mov	w0, #0
-            .Lreturn_foo:
+            Lreturn_foo:
                 ldp	x29, x30, [sp], 16
                 ret
             "
@@ -960,9 +960,9 @@ mod tests {
                 ldr	w7, [sp, 8]
                 bl	_foo
                 add	sp, sp, 16
-                b	.Lreturn_main
+                b	Lreturn_main
                 mov	w0, #0
-            .Lreturn_main:
+            Lreturn_main:
                 ldp	x29, x30, [sp], 16
                 ret
             "
@@ -992,7 +992,7 @@ mod tests {
                     stp	x29, x30, [sp, -16]!
                     mov	x29, sp
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1046,9 +1046,9 @@ mod tests {
                     mov	x29, sp
                     mov	w0, #2
                     mvn	w0, w0
-                    b	.Lreturn_main
+                    b	Lreturn_main
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1136,9 +1136,9 @@ mod tests {
                     ldr	w1, [sp, 12]
                     add	sp, sp, 16
                     add	w0, w1, w0
-                    b	.Lreturn_main
+                    b	Lreturn_main
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1182,17 +1182,17 @@ mod tests {
                     ldr	w1, [sp, 12]
                     add	sp, sp, 16
                     cmp	w1, 0
-                    beq	.L1
+                    beq	L1
                     cmp	w0, 0
-                    beq	.L1
+                    beq	L1
                     mov	w0, 1
-                    b	.L2
-                .L1:
+                    b	L2
+                L1:
                     mov	w0, 0
-                .L2:
-                    b	.Lreturn_main
+                L2:
+                    b	Lreturn_main
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1231,7 +1231,7 @@ mod tests {
                     str	w0, [sp, 12]
                     add	sp, sp, 16
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1310,7 +1310,7 @@ mod tests {
                     str	w0, [sp, 8]
                     add	sp, sp, 16
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1416,7 +1416,7 @@ mod tests {
                     add	sp, sp, 16
                     add	sp, sp, 16
                     mov	w0, #0
-                .Lreturn_main:
+                Lreturn_main:
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1512,7 +1512,7 @@ mod tests {
                     add	sp, sp, 16
                     add	sp, sp, 16
                     mov	w0, #0
-                .Lreturn_main:                    
+                Lreturn_main:                    
                     ldp	x29, x30, [sp], 16
                     ret
             "
@@ -1579,12 +1579,12 @@ mod tests {
             "
                     mov	w0, #1
                     cmp	w0, 0
-                    beq	.L1
+                    beq	L1
                     mov	w0, #2
-                    b	.L2
-                .L1:
+                    b	L2
+                L1:
                     mov	w0, #3
-                .L2:
+                L2:
             "
         )
     }
@@ -1616,12 +1616,12 @@ mod tests {
             "
                     mov	w0, #1
                     cmp	w0, 0
-                    beq	.L1
+                    beq	L1
                     mov	w0, #2
-                    b	.Lreturn_main
-                    b	.L2
-                .L1:
-                .L2:
+                    b	Lreturn_main
+                    b	L2
+                L1:
+                L2:
             "
         )
     }
@@ -1655,14 +1655,14 @@ mod tests {
             "
                     mov	w0, #1
                     cmp	w0, 0
-                    beq	.L1
+                    beq	L1
                     mov	w0, #2
-                    b	.Lreturn_main
-                    b	.L2
-                .L1:
+                    b	Lreturn_main
+                    b	L2
+                L1:
                     mov	w0, #3
-                    b	.Lreturn_main
-                .L2:
+                    b	Lreturn_main
+                L2:
             "
         )
     }
@@ -1711,7 +1711,7 @@ mod tests {
                     mov	w0, #0
                     sub	sp, sp, #16
                     str	w0, [sp, 12]
-                .L1:
+                L1:
                     ldr	w0, [sp, 12]
                     str	w0, [sp, 8]
                     mov	w0, #5
@@ -1719,17 +1719,17 @@ mod tests {
                     cmp	w1, w0
                     cset	w0, lt
                     cmp	w0, 0
-                    beq	.L3
+                    beq	L3
                     mov	w0, #2
-                .L2:
+                L2:
                     ldr	w0, [sp, 12]
                     str	w0, [sp, 8]
                     mov	w0, #1
                     ldr	w1, [sp, 8]
                     add	w0, w1, w0
                     str	w0, [sp, 12]
-                    b	.L1
-                .L3:
+                    b	L1
+                L3:
                     add	sp, sp, 16
             "
         )
@@ -1765,7 +1765,7 @@ mod tests {
         assert_str_trim_eq!(
             result,
             "
-                .L1:
+                L1:
                     ldr	w0, [sp, 12]
                     str	w0, [sp, 8]
                     mov	w0, #5
@@ -1773,11 +1773,11 @@ mod tests {
                     cmp	w1, w0
                     cset	w0, lt
                     cmp	w0, 0
-                    beq	.L3
+                    beq	L3
                     mov	w0, #2
-                .L2:
-                    b	.L1
-                .L3:
+                L2:
+                    b	L1
+                L3:
             "
         )
     }
@@ -1812,9 +1812,9 @@ mod tests {
         assert_str_trim_eq!(
             result,
             "
-                .L1:
+                L1:
                     mov	w0, #2
-                .L2:
+                L2:
                     ldr	w0, [sp, 12]
                     str	w0, [sp, 8]
                     mov	w0, #5
@@ -1822,9 +1822,9 @@ mod tests {
                     cmp	w1, w0
                     cset	w0, lt
                     cmp	w0, 0
-                    beq	.L3
-                    b	.L1
-                .L3:
+                    beq	L3
+                    b	L1
+                L3:
             "
         )
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -42,30 +42,27 @@ impl Codegen {
 
         // populate global variable map
         for node in function_or_declaration_list.iter() {
-            match node {
-                AstNode::Declare { variable, expression } => {
-                                        // populate the global variable map
-                    // can be declared many times, but defined only once
-                    if let Some(val) = self.global_variable_map.get(variable) {
-                        let already_initialized = val.is_some();
-                        let is_initialized = expression.is_some();
-                        if already_initialized && is_initialized {
-                            return Err(anyhow!("Global variable defined twice"));
-                        }
+            if let AstNode::Declare { variable, expression } = node {
+                // populate the global variable map
+                // can be declared many times, but defined only once
+                if let Some(val) = self.global_variable_map.get(variable) {
+                    let already_initialized = val.is_some();
+                    let is_initialized = expression.is_some();
+                    if already_initialized && is_initialized {
+                        return Err(anyhow!("Global variable defined twice"));
                     }
-
-                    let constant_option = match expression {
-                        Some(boxed) => {
-                            let AstNode::Constant { constant } = **boxed else {
-                                return Err(anyhow!("Global variable defined with non-constant expression"))
-                            };
-                            Some(constant)
-                        }
-                        None => None
-                    };
-                    self.global_variable_map.insert(variable.clone(), constant_option);
                 }
-                _ => {} // do nothing
+
+                let constant_option = match expression {
+                    Some(boxed) => {
+                        let AstNode::Constant { constant } = **boxed else {
+                            return Err(anyhow!("Global variable defined with non-constant expression"))
+                        };
+                        Some(constant)
+                    }
+                    None => None
+                };
+                self.global_variable_map.insert(variable.clone(), constant_option);
             }
         }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -135,7 +135,7 @@ impl AstNode {
         let mut token_iter = peek_nth(tokens.iter());
         let mut function_or_declaration_list: Vec<Self> = Vec::new();
         loop {
-            if token_iter.peek() == None {
+            if token_iter.peek().is_none() {
                 return Ok(Self::Program { function_or_declaration_list });
             }
             let Some(TokenType::Keyword(s)) = token_iter.peek() else {

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -22,6 +22,9 @@ impl Validation {
             return Err(anyhow!("Called validate_ast on node that is not a program"));
         };
 
+        let mut function_set: HashSet<&str> = HashSet::new();
+        let mut global_var_map: HashMap<&str, bool> = HashMap::new();  // value: has been initialized
+
         // track function declarations/definitions
         for node in function_or_declaration_list {
             match node {
@@ -30,10 +33,30 @@ impl Validation {
                     ref parameters,
                     body: ref statement,
                 } => {
+                    if global_var_map.contains_key(&function_name[..]) {
+                        return Err(anyhow!("function name already used as global variable name"));
+                    }
+                    function_set.insert(&function_name);
                     self.validate_function(function_name, parameters, statement)?;
                 }
-                AstNode::Declare { variable: _, expression: _ } => {
-                    self.validate_block_item(node)?;
+                AstNode::Declare { ref variable, ref expression } => {
+                    if function_set.contains(&variable[..]) {
+                        return Err(anyhow!("global variable name already used as function name"));
+                    }
+                    if let Some(is_initialized) = global_var_map.get(&variable[..]) {
+                        if *is_initialized {
+                            return Err(anyhow!("global variable initialized already"));
+                        }
+                    }
+                    global_var_map.insert(&variable, expression.is_some());
+                    if let Some(boxed) = expression {
+                        match **boxed {
+                            AstNode::Constant { constant: _ } => {}  // do nothing
+                            _ => {
+                                return Err(anyhow!("global variable can only be initialized as constant"));
+                            }
+                        }
+                    }
                 }
                 _ => {
                     return Err(anyhow!("Program contains top-level node that is not function or declaration"));

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -18,7 +18,7 @@ impl Validation {
     }
 
     pub fn validate_ast(&mut self, ast: &AstNode) -> anyhow::Result<()> {
-        let AstNode::Program { function_list } = ast else {
+        let AstNode::Program { function_or_declaration_list: function_list } = ast else {
             return Err(anyhow!("Called validate_ast on node that is not a program"));
         };
 
@@ -234,7 +234,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function],
+            function_or_declaration_list: vec![function],
         };
 
         let mut validation = Validation::new();
@@ -263,7 +263,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function_1, function_2],
+            function_or_declaration_list: vec![function_1, function_2],
         };
 
         let mut validation = Validation::new();
@@ -286,7 +286,7 @@ mod tests {
             body: None,
         };
         let program = AstNode::Program {
-            function_list: vec![declaration_1, declaration_2],
+            function_or_declaration_list: vec![declaration_1, declaration_2],
         };
 
         let mut validation = Validation::new();
@@ -314,7 +314,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![declaration, definition],
+            function_or_declaration_list: vec![declaration, definition],
         };
 
         let mut validation = Validation::new();
@@ -346,7 +346,7 @@ mod tests {
         };
         // helper function declared after main
         let program = AstNode::Program {
-            function_list: vec![function_2, function_1],
+            function_or_declaration_list: vec![function_2, function_1],
         };
 
         let mut validation = Validation::new();
@@ -375,7 +375,7 @@ mod tests {
             })),
         };
         let program = AstNode::Program {
-            function_list: vec![function_1, function_2],
+            function_or_declaration_list: vec![function_1, function_2],
         };
 
         let mut validation = Validation::new();

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -36,7 +36,7 @@ impl Validation {
                     if global_var_map.contains_key(&function_name[..]) {
                         return Err(anyhow!("function name already used as global variable name"));
                     }
-                    function_set.insert(&function_name);
+                    function_set.insert(function_name);
                     self.validate_function(function_name, parameters, statement)?;
                 }
                 AstNode::Declare { ref variable, ref expression } => {
@@ -48,7 +48,7 @@ impl Validation {
                             return Err(anyhow!("global variable initialized already"));
                         }
                     }
-                    global_var_map.insert(&variable, expression.is_some());
+                    global_var_map.insert(variable, expression.is_some());
                     if let Some(boxed) = expression {
                         match **boxed {
                             AstNode::Constant { constant: _ } => {}  // do nothing
@@ -70,7 +70,7 @@ impl Validation {
     fn validate_function(
         &mut self, 
         function_name: &String, 
-        parameters: &Vec<String>, 
+        parameters: &[String], 
         statement: &Option<Box<AstNode>>,
     ) -> anyhow::Result<()> {
         match statement {


### PR DESCRIPTION
Support global variables! Use `PAGEOFF` assembler directive to access symbols that are defined when declared (guaranteed to be on the current page). Use `GOTPAGEOFF` to access symbols that are not defined at declaration since the symbol might be defined in a different module or shared library.